### PR TITLE
Fixed argument order in implode call

### DIFF
--- a/view/layout/layout.phtml
+++ b/view/layout/layout.phtml
@@ -61,7 +61,7 @@ $userBar = $this->userBar();
             <footer>
                 <div>
                     <div class="admin-link">
-                        <a href="<?php echo implode(array_diff(explode("/", $site->adminUrl()),['site','s',$site->slug()]),"/"); ?>">Omeka-S Login</a>
+                        <a href="<?php echo implode('/', array_diff(explode("/", $site->adminUrl()),['site','s',$site->slug()])); ?>">Omeka-S Login</a>
                     </div>
                 </div>
             </footer>


### PR DESCRIPTION
Fixing error:

`May 09 12:25:06 maui.dartmouth.edu php[10842]: PHP Deprecated:  implode(): Passing glue string after array is deprecated. Swap the parameters in /data/omeka/sites/prod/site/themes/basicdartmouth/view/layout/layout.phtml on line 64`